### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Build and test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/marekjedrzejewski/ping-pong-api/security/code-scanning/1](https://github.com/marekjedrzejewski/ping-pong-api/security/code-scanning/1)

To fix the problem, you should add a `permissions:` block to the workflow file that specifies the minimum privileges required. In this case, since the workflow only checks out source code and runs build/tests, it only needs read access to repository contents. This can be accomplished by adding:

```yaml
permissions:
  contents: read
```

at the top level of the workflow, directly beneath the workflow name (before or after the `on:` block). This change limits the `GITHUB_TOKEN` permissions for all jobs in the workflow to read-only for repository contents, minimizing risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
