### PR TITLE
Add API docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ping_pong_api"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "axum",
  "axum-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ping_pong_api"
-version = "0.1.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]
@@ -10,7 +10,11 @@ jiff = { version = "0.2.23", features = ["serde"] }
 log = "0.4.29"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.149"
-sqlx = { version = "0.8.6", features = ["postgres", "runtime-tokio", "tls-native-tls"] }
+sqlx = { version = "0.8.6", features = [
+    "postgres",
+    "runtime-tokio",
+    "tls-native-tls",
+] }
 tokio = { version = "1.50.0", features = [
     "macros",
     "rt-multi-thread",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ but beware, everyone, including your mom, can grab any paddle and swing it aroun
 ...and you probably will have to wait for the instance to spin up.
 
 ## Endpoints
-- `/` has list of open matches
+- `/` will redirect you to `/api-docs`
+- `/matches` has list of open matches
 - `/matches/{id}` - has match status
 - `/matches/{id}/ping` lets you swing paddle on one side
 - `/matches/{id}/pong` lets you swing paddle on the other side

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ but beware, everyone, including your mom, can grab any paddle and swing it aroun
 
 ## Endpoints
 - `/` has list of open matches
-- `/match/{id}` - has match status
-- `/match/{id}/ping` lets you swing paddle on one side
-- `/match/{id}/pong` lets you swing paddle on the other side
+- `/matches/{id}` - has match status
+- `/matches/{id}/ping` lets you swing paddle on one side
+- `/matches/{id}/pong` lets you swing paddle on the other side
 
 Everything is using `GET` so you can just put it in your browser address.

--- a/src/api_docs.rs
+++ b/src/api_docs.rs
@@ -1,7 +1,12 @@
-use axum::{Router, response::Html, routing::get};
+use axum::{
+    Router,
+    response::{Html, Redirect},
+    routing::get,
+};
 
 pub fn create_api_docs() -> Router {
     Router::new()
+        .route("/", get(|| async { Redirect::permanent("/api-docs") }))
         .route("/api-docs", get(scalar_ui))
         .route("/api-docs/openapi.yaml", get(openapi_spec))
 }

--- a/src/api_docs.rs
+++ b/src/api_docs.rs
@@ -1,0 +1,33 @@
+use axum::{Router, response::Html, routing::get};
+
+pub fn create_api_docs() -> Router {
+    Router::new()
+        .route("/api-docs", get(scalar_ui))
+        .route("/api-docs/openapi.yaml", get(openapi_spec))
+}
+
+async fn openapi_spec() -> &'static str {
+    include_str!("openapi.yaml")
+}
+
+async fn scalar_ui() -> Html<&'static str> {
+    Html(
+        r#"
+<!doctype html>
+<html>
+  <head>
+    <title>API Docs</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/api-docs/openapi.yaml">
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+    "#,
+    )
+}

--- a/src/api_docs.rs
+++ b/src/api_docs.rs
@@ -36,3 +36,36 @@ async fn scalar_ui() -> Html<&'static str> {
     "#,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::create_api_docs;
+    use axum::http::StatusCode;
+    use axum_test::TestServer;
+
+    const API_DOCS_PATH: &str = "/api-docs";
+    fn setup_server() -> TestServer {
+        TestServer::builder().build(create_api_docs()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn api_docs_served_from_root() {
+        let server = setup_server();
+        let root_response = server.get("/").await;
+        root_response.assert_status(StatusCode::PERMANENT_REDIRECT);
+        root_response.assert_header("location", API_DOCS_PATH);
+
+        let docs_response = server.get(API_DOCS_PATH).await;
+        docs_response.assert_status_ok();
+        docs_response.assert_text_contains("API Docs");
+    }
+
+    // can't put all in one test. Content js-generated - transparent to tests.
+    #[tokio::test]
+    async fn openapi_spec_served() {
+        let server = setup_server();
+        let response = server.get("/api-docs/openapi.yaml").await;
+        response.assert_status_ok();
+        response.assert_text_contains("title: Ping Pong API");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub fn create_app_from_state(state: AppState) -> Router {
         .allow_headers(Any);
 
     Router::new()
-        .route("/", get(open_matches))
+        .route("/matches", get(open_matches))
         .nest("/matches/{id}", match_routes(state.clone()))
         .with_state(state)
         .layer(cors)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub fn create_app_from_state(state: AppState) -> Router {
 
     Router::new()
         .route("/", get(open_matches))
-        .nest("/match/{id}", match_routes(state.clone()))
+        .nest("/matches/{id}", match_routes(state.clone()))
         .with_state(state)
         .layer(cors)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,10 @@ use ping_pong_api::create_app;
 
 use ping_pong_api::database::init_db;
 
+mod api_docs;
+
+use api_docs::create_api_docs;
+
 #[tokio::main]
 async fn main() {
     env_logger::init();
@@ -21,10 +25,11 @@ async fn main() {
     match pool {
         Ok(p) => {
             let app = create_app(p).await;
+            let api_docs = create_api_docs();
             let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{server_port}"))
                 .await
                 .unwrap();
-            axum::serve(listener, app)
+            axum::serve(listener, app.merge(api_docs))
                 .with_graceful_shutdown(shutdown_signal())
                 .await
                 .unwrap();

--- a/src/models/game.rs
+++ b/src/models/game.rs
@@ -65,7 +65,7 @@ pub struct RallyState {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct RallyStatistics {
+pub struct LongestRally {
     hit_count: usize,
     duration: SignedDuration,
 }
@@ -75,7 +75,7 @@ pub struct RallyStatistics {
 pub struct GameState {
     pub server: Side,
     pub score: Score,
-    pub longest_rally: Option<RallyStatistics>,
+    pub longest_rally: Option<LongestRally>,
 }
 
 /// Updates longest rally - hit count based.
@@ -90,7 +90,7 @@ fn update_statistics(
         let current_rally_time = clock::now().duration_since(start);
         match &mut game_state.longest_rally {
             None => {
-                game_state.longest_rally = Some(RallyStatistics {
+                game_state.longest_rally = Some(LongestRally {
                     hit_count: rally_state.hit_count,
                     duration: current_rally_time,
                 })

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -6,7 +6,9 @@ info:
 
 tags:
   - name: Matches
-    description: View and play ping pong matches.
+    description: >
+      View and play ping pong matches.
+      For now non-existing matches are created on access, so get it while you can!
 
 paths:
   /:

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -44,6 +44,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MatchDetails"
+        "400":
+          $ref: "#/components/responses/InvalidMatchId"
 
   /matches/{matchId}/ping:
     get:
@@ -61,9 +63,11 @@ paths:
             text/plain:
               schema:
                 type: string
-                enum: [pong]
+                const: pong
         "409":
           $ref: "#/components/responses/HitMiss"
+        "400":
+          $ref: "#/components/responses/InvalidMatchId"
 
   /matches/{matchId}/pong:
     get:
@@ -81,9 +85,11 @@ paths:
             text/plain:
               schema:
                 type: string
-                enum: [ping]
+                const: ping
         "409":
           $ref: "#/components/responses/HitMiss"
+        "400":
+          $ref: "#/components/responses/InvalidMatchId"
 
 components:
   parameters:
@@ -91,9 +97,11 @@ components:
       in: path
       name: matchId
       required: true
-      description: Unique identifier of the match.
+      description: Unique identifier of the match. Lowercase letters and digits only, max length 6.
       schema:
         type: string
+        maxLength: 6
+        pattern: "^[a-z0-9]+$"
         examples: ["match1"]
 
   responses:
@@ -103,7 +111,14 @@ components:
         text/plain:
           schema:
             type: string
-            enum: [MISS]
+            const: MISS
+    InvalidMatchId:
+      description: Match ID format invalid.
+      content:
+        text/plain:
+          schema:
+            type: string
+            const: "Invalid Table UID format. Must be at most 6 characters long and contain only lowercase letters and digits."
   schemas:
     Side:
       type: string
@@ -116,8 +131,10 @@ components:
       properties:
         ping:
           type: integer
+          minimum: 0
         pong:
           type: integer
+          minimum: 0
 
     LongestRally:
       type: object

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -145,6 +145,7 @@ components:
       properties:
         hitCount:
           type: integer
+          minimum: 0
         duration:
           type: string
           format: duration

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,11 +1,17 @@
 openapi: 3.1.0
 info:
   title: Ping Pong API
-  version: 0.1.0
+  version: 0.3.0
+  description: View and play Ping Pong matches. Designed to be playable by simply opening the match page in a browser.
+
+tags:
+  - name: Matches
+    description: View and play ping pong matches.
 
 paths:
   /:
     get:
+      tags: [Matches]
       summary: List open matches
       responses:
         "200":
@@ -20,9 +26,14 @@ paths:
                     type: array
                     items:
                       type: string
+              examples:
+                example:
+                  value:
+                    openMatches: ["match1", "match2"]
 
   /matches/{matchId}:
     get:
+      tags: [Matches]
       summary: Get match details
       parameters:
         - $ref: "#/components/parameters/matchId"
@@ -36,6 +47,7 @@ paths:
 
   /matches/{matchId}/ping:
     get:
+      tags: [Matches]
       summary: Hit from the ping side
       description: >
         You might wonder why it's GET and response is plaintext.
@@ -55,6 +67,7 @@ paths:
 
   /matches/{matchId}/pong:
     get:
+      tags: [Matches]
       summary: Hit from the pong side
       description: >
         You might wonder why it's GET and response is plaintext.
@@ -81,7 +94,7 @@ components:
       description: Unique identifier of the match.
       schema:
         type: string
-        example: "match1"
+        examples: ["match1"]
 
   responses:
     HitMiss:
@@ -159,3 +172,17 @@ components:
           $ref: "#/components/schemas/RallyState"
         gameState:
           $ref: "#/components/schemas/GameState"
+      examples:
+        - rallyState:
+            side: ping
+            hitTimeoutTimestamp: "2026-03-25T10:45:03.73229592Z"
+            serveTimestamp: "2026-03-25T10:44:18.73230072Z"
+            hitCount: 5
+          gameState:
+            server: pong
+            score:
+              ping: 3
+              pong: 4
+            longestRally:
+              hitCount: 10
+              duration: "PT1M30S"

--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1,0 +1,161 @@
+openapi: 3.1.0
+info:
+  title: Ping Pong API
+  version: 0.1.0
+
+paths:
+  /:
+    get:
+      summary: List open matches
+      responses:
+        "200":
+          description: List of open match IDs
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [openMatches]
+                properties:
+                  openMatches:
+                    type: array
+                    items:
+                      type: string
+
+  /matches/{matchId}:
+    get:
+      summary: Get match details
+      parameters:
+        - $ref: "#/components/parameters/matchId"
+      responses:
+        "200":
+          description: Match details
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MatchDetails"
+
+  /matches/{matchId}/ping:
+    get:
+      summary: Hit from the ping side
+      description: >
+        You might wonder why it's GET and response is plaintext.
+        This is intentional - to allow playing the game by simply opening the page in the browser.
+      parameters:
+        - $ref: "#/components/parameters/matchId"
+      responses:
+        "200":
+          description: Hit registered.
+          content:
+            text/plain:
+              schema:
+                type: string
+                enum: [pong]
+        "409":
+          $ref: "#/components/responses/HitMiss"
+
+  /matches/{matchId}/pong:
+    get:
+      summary: Hit from the pong side
+      description: >
+        You might wonder why it's GET and response is plaintext.
+        This is intentional - to allow playing the game by simply opening the page in the browser.
+      parameters:
+        - $ref: "#/components/parameters/matchId"
+      responses:
+        "200":
+          description: Hit registered.
+          content:
+            text/plain:
+              schema:
+                type: string
+                enum: [ping]
+        "409":
+          $ref: "#/components/responses/HitMiss"
+
+components:
+  parameters:
+    matchId:
+      in: path
+      name: matchId
+      required: true
+      description: Unique identifier of the match.
+      schema:
+        type: string
+        example: "match1"
+
+  responses:
+    HitMiss:
+      description: Miss — hit attempted from the wrong side.
+      content:
+        text/plain:
+          schema:
+            type: string
+            enum: [MISS]
+  schemas:
+    Side:
+      type: string
+      description: Which side of the table is currently serving or hitting.
+      enum: [ping, pong]
+
+    Score:
+      type: object
+      required: [ping, pong]
+      properties:
+        ping:
+          type: integer
+        pong:
+          type: integer
+
+    LongestRally:
+      type: object
+      description: Longest (by hit count) rally in the match. Duration included, but not a qualifying factor.
+      required: [hitCount, duration]
+      properties:
+        hitCount:
+          type: integer
+        duration:
+          type: string
+          format: duration
+
+    RallyState:
+      type: object
+      description: Current state of the ongoing rally.
+      required: [side, hitCount]
+      properties:
+        side:
+          $ref: "#/components/schemas/Side"
+        hitTimeoutTimestamp:
+          type: [string, "null"]
+          format: date-time
+          description: Time at which point will be lost if hit is not returned. Null if rally has not started yet.
+        serveTimestamp:
+          type: [string, "null"]
+          format: date-time
+          description: Time at which first hit of the rally was made. Null if rally has not started yet.
+        hitCount:
+          type: integer
+          description: Number of hits from both sides since the start of the rally.
+
+    GameState:
+      type: object
+      description: High-level game state, excluding current rally details.
+      required: [server, score]
+      properties:
+        server:
+          $ref: "#/components/schemas/Side"
+        score:
+          $ref: "#/components/schemas/Score"
+        longestRally:
+          oneOf:
+            - $ref: "#/components/schemas/LongestRally"
+            - type: "null"
+
+    MatchDetails:
+      type: object
+      description: Complete details about a match.
+      required: [rallyState, gameState]
+      properties:
+        rallyState:
+          $ref: "#/components/schemas/RallyState"
+        gameState:
+          $ref: "#/components/schemas/GameState"

--- a/src/tests/features/multiple_matches.rs
+++ b/src/tests/features/multiple_matches.rs
@@ -2,8 +2,8 @@ use serde_json::json;
 
 use crate::tests::utils::{setup_test_server, setup_test_server_with_matches};
 
-pub const MATCH_A: &str = "/match/a";
-pub const MATCH_B: &str = "/match/b";
+pub const MATCH_A: &str = "/matches/a";
+pub const MATCH_B: &str = "/matches/b";
 pub const MATCH_IDS: &[&str] = &["a", "b"];
 
 #[tokio::test]
@@ -39,7 +39,7 @@ async fn matches_are_isolated() {
 async fn invalid_match_id_returns_bad_request() {
     let server = setup_test_server();
 
-    let response = server.get("/match/INVALID").await;
+    let response = server.get("/matches/INVALID").await;
     response.assert_status_bad_request();
     response.assert_text_contains(
         "at most 6 characters long and contain only lowercase letters and digits",

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 
 pub const MATCH_ID: &str = "test";
-pub const MATCH_ENDPOINT: &str = "/match/test";
-pub const PING_ENDPOINT: &str = "/match/test/ping";
-pub const PONG_ENDPOINT: &str = "/match/test/pong";
+pub const MATCH_ENDPOINT: &str = "/matches/test";
+pub const PING_ENDPOINT: &str = "/matches/test/ping";
+pub const PONG_ENDPOINT: &str = "/matches/test/pong";
 
 pub fn setup_test_server() -> TestServer {
     setup_test_server_with_matches(&[MATCH_ID])

--- a/tests/integration_tests/test_multi_match.rs
+++ b/tests/integration_tests/test_multi_match.rs
@@ -10,7 +10,7 @@ async fn test_multi_match() {
     let api_port = get_random_port();
     let api_endpoint = format!("http://127.0.0.1:{api_port}");
     let get_match_list = || async {
-        reqwest::get(&format!("{api_endpoint}/"))
+        reqwest::get(&format!("{api_endpoint}/matches"))
             .await
             .unwrap()
             .json()
@@ -25,7 +25,7 @@ async fn test_multi_match() {
     assert!(match_list["openMatches"].as_array().unwrap().is_empty());
 
     // 2. Create by access: GET /match/m1 and then verify / contains ["m1"]
-    let _ = reqwest::get(&format!("{api_endpoint}/match/m1"))
+    let _ = reqwest::get(&format!("{api_endpoint}/matches/m1"))
         .await
         .unwrap();
     let match_list: Value = get_match_list().await;
@@ -34,7 +34,7 @@ async fn test_multi_match() {
     assert_eq!(open_matches[0], "m1");
 
     // 3. Add another: GET /match/m2 and verify / contains both
-    let _ = reqwest::get(&format!("{api_endpoint}/match/m2"))
+    let _ = reqwest::get(&format!("{api_endpoint}/matches/m2"))
         .await
         .unwrap();
     let match_list: Value = get_match_list().await;
@@ -45,14 +45,14 @@ async fn test_multi_match() {
     assert!(ids.contains(&"m2"));
 
     // 4. No duplicates: GET /match/m1 again
-    let _ = reqwest::get(&format!("{api_endpoint}/match/m1"))
+    let _ = reqwest::get(&format!("{api_endpoint}/matches/m1"))
         .await
         .unwrap();
     let match_list: Value = get_match_list().await;
     assert_eq!(match_list["openMatches"].as_array().unwrap().len(), 2);
 
     // 5. Invalid ID check
-    let resp = reqwest::get(&format!("{api_endpoint}/match/INVALID_ID"))
+    let resp = reqwest::get(&format!("{api_endpoint}/matches/INVALID_ID"))
         .await
         .unwrap();
     assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);

--- a/tests/integration_tests/test_persistence.rs
+++ b/tests/integration_tests/test_persistence.rs
@@ -10,7 +10,7 @@ async fn test_persistence() {
     let (connection_string, _db) = setup_db().await;
     let api_port = get_random_port();
     let api_endpoint = format!("http://127.0.0.1:{api_port}");
-    let match_endpoint = format!("{api_endpoint}/match/test");
+    let match_endpoint = format!("{api_endpoint}/matches/test");
     let ping_endpoint = format!("{match_endpoint}/ping");
     let pong_endpoint = format!("{match_endpoint}/pong");
 


### PR DESCRIPTION
This PR resolves https://github.com/marekjedrzejewski/ping-pong-api/issues/9

It adds `openapi.yaml` served with basic scalar endpoint. Root now redirects to api-docs and `match` became `matches`, as rest conventionally uses plural, which I overlooked before.

Maybe in future this should be moved to some library like utoipa, but for now it works pretty ok.